### PR TITLE
Social links centering

### DIFF
--- a/_sass/_default.scss
+++ b/_sass/_default.scss
@@ -110,6 +110,7 @@ strong {
     font-size: 24px;
     color: $cloudy;
     list-style-type: none;
+    padding-left: 0;
 }
 
 .social-links__entry {

--- a/_sass/_default.scss
+++ b/_sass/_default.scss
@@ -72,10 +72,6 @@ strong {
     overflow: hidden;
 }
 
-.navigation {
-    float:left;
-}
-
 .logo {
     font-size: 50px;
     font-weight: 700;
@@ -106,7 +102,7 @@ strong {
 }
 
 .social-links {
-	float:left;
+    @include centered-block();
     font-size: 24px;
     color: $cloudy;
     list-style-type: none;
@@ -256,8 +252,7 @@ strong {
         width: 80%;
     }
 
-    .navigation,
-    .social-links {
+    .navigation {
 		@include centered-block();
     }
 


### PR DESCRIPTION
Two related fixes, of which you might only want the first (which is why I left them in separate commits).

3b796c1 fixes social links centering on mobile.
362ea67 centers them on larger/desktop screens also.